### PR TITLE
藏着掖着

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-<div align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=yuygfgg&locale=en&rank_icon=percentile"/>
-</div>
+藏着掖着


### PR DESCRIPTION
## Summary by Sourcery

Update README content to remove the GitHub stats widget and replace it with a simple placeholder phrase.

Documentation:
- Remove the centered GitHub stats card from the README
- Add the phrase “藏着掖着” as the sole content of the README